### PR TITLE
Expose the router of bosh-lite to the internet

### DIFF
--- a/aws/Makefile
+++ b/aws/Makefile
@@ -6,6 +6,8 @@ PROJECT_DIR := ${CURRENT_DIR}/..
 UNAME_S := $(shell uname -s)
 
 export DEPLOY_ENV := bosh-lite-1
+export DNS_ZONE_NAME := sandbox.keytwine.com
+export PUBLIC_SYSTEM_DOMAIN := ${DEPLOY_ENV}.${DNS_ZONE_NAME}
 
 help:
 	@grep -hE '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/aws/Makefile
+++ b/aws/Makefile
@@ -14,3 +14,4 @@ include Makefile.terraform
 include Makefile.bosh
 include Makefile.cf
 include Makefile.prometheus
+include Makefile.nginx

--- a/aws/Makefile.bosh
+++ b/aws/Makefile.bosh
@@ -89,7 +89,8 @@ bosh-terminate: load_bosh_creds load_terraform_outputs ## Terminate the bosh lit
 		--region ${REGION} \
 		--instance-ids ${BOSH_INSTANCE_ID}
 	./terraform/run-terraform.sh destroy -force -target=aws_eip.bosh_lite
-
+	# Remove the creds, as all the certs would be invalid if the IP changes
+	rm -f generated/bosh-creds.yml
 
 bosh-wakeup: load_bosh_creds load_terraform_outputs ## Start the bosh lite instance and restart the gardens/vms from the deployments
 	$(eval export INSTANCE_ID=$(shell jq -r .current_vm_cid < state.json))

--- a/aws/Makefile.bosh
+++ b/aws/Makefile.bosh
@@ -29,6 +29,8 @@ bosh-interpolate-manifest: load_terraform_outputs ## interpolate the bosh manife
 		-o ops-files/bosh/external-ip-ssh-tunnel.yml \
 		-v external_ip=${BOSH_LITE_EXTERNAL_IP} \
 		\
+		-o ops-files/bosh/forward-port-nginx.yml \
+		\
 		-v director_name="Bosh Lite Director on AWS" \
 		\
 		--vars-store ./generated/bosh-creds.yml \

--- a/aws/Makefile.nginx
+++ b/aws/Makefile.nginx
@@ -1,0 +1,14 @@
+nginx-interpolate-manifest: load_bosh_creds ## Interpolate the prometheus manifest
+	bosh -n -e aws-bosh-lite -d nginx interpolate \
+		\
+		manifests/nginx.yml \
+		-v system_domain=bosh-lite.com \
+		\
+ 		--vars-store generated/nginx-creds.yml \
+        \
+        > generated/nginx-manifest.yml
+
+nginx-deploy: nginx-interpolate-manifest ## Deploy the CF on bosh-lite
+	bosh -n -e aws-bosh-lite -d nginx deploy \
+		generated/nginx-manifest.yml
+

--- a/aws/Makefile.nginx
+++ b/aws/Makefile.nginx
@@ -3,6 +3,7 @@ nginx-interpolate-manifest: load_bosh_creds ## Interpolate the prometheus manife
 		\
 		manifests/nginx.yml \
 		-v system_domain=bosh-lite.com \
+                -v public_system_domain=${PUBLIC_SYSTEM_DOMAIN} \
 		\
  		--vars-store generated/nginx-creds.yml \
         \

--- a/aws/Makefile.prometheus
+++ b/aws/Makefile.prometheus
@@ -1,6 +1,4 @@
-prometheus-interpolate-manifest: load_bosh_creds ## Interpolate the prometheus manifest
-	$(eval include ./generated/terraform_outputs_vars.sh)
-
+prometheus-interpolate-manifest: load_bosh_creds load_terraform_outputs ## Interpolate the prometheus manifest
 	$(eval export UAA_CLIENTS_CF_EXPORTER_SECRET=$(shell bosh int generated/cf-creds.yml --path /uaa_clients_cf_exporter_secret))
 	$(eval export UAA_CLIENTS_FIREHOSE_EXPORTER_SECRET=$(shell bosh int generated/cf-creds.yml --path /uaa_clients_firehose_exporter_secret))
 
@@ -10,11 +8,14 @@ prometheus-interpolate-manifest: load_bosh_creds ## Interpolate the prometheus m
 	bosh -n -e aws-bosh-lite -d prometheus interpolate \
 		${PROJECT_DIR}/prometheus-boshrelease/manifests/prometheus.yml \
 		-v metrics_environment=prometheus \
+		-v metron_deployment_name=prometheus \
 		-v skip_ssl_verify=true \
 		\
 		-o ${PROJECT_DIR}/prometheus-boshrelease/manifests/operators/enable-cf-route-registrar.yml \
-		-v metron_deployment_name=prometheus \
 		-v system_domain=bosh-lite.com \
+		\
+		-o ops-files/prometheus/register_public_domains.yml \
+		-v public_system_domain=${PUBLIC_SYSTEM_DOMAIN} \
 		\
 		-o ${PROJECT_DIR}/prometheus-boshrelease/manifests/operators/monitor-cf.yml \
 		-v uaa_clients_cf_exporter_secret="${UAA_CLIENTS_CF_EXPORTER_SECRET}" \

--- a/aws/manifests/nginx.yml
+++ b/aws/manifests/nginx.yml
@@ -1,0 +1,101 @@
+---
+name: nginx
+
+releases:
+- name: nginx
+  #version: "1.12.2"
+  #url: https://github.com/cloudfoundry-community/nginx-release/releases/download/v1.12.2/nginx-1.12.2.tgz
+  #sha1: e5e5f54d46e2a70fac85ba16e96ccb7e4148bdfa
+  version: "1.12.2+dev.9"
+  url: https://github.com/keymon/nginx-release/releases/download/1.12.2%2Bdev.9/nginx-release-1.12.2.dev.9.tar.gz
+  sha1: a3e6b1f4d327c8269d5108751da0b4e4a2733714
+
+stemcells:
+- alias: ubuntu
+  os: ubuntu-trusty
+  version: latest
+
+instance_groups:
+- name: nginx
+  instances: 1
+  azs: [ z1 ]
+  vm_type: default
+  persistent_disk_type: 1GB
+  stemcell: ubuntu
+  networks:
+  - name: default
+  jobs:
+  - name: nginx
+    release: nginx
+    properties:
+      htpasswd_users:
+      - name: bosh-lite
+        password: ((nginx_basic_auth_password))
+      ssl_key: ((nginx.private_key))
+      ssl_chained_cert: ((nginx.certificate))
+      nginx_conf: |
+        worker_processes  1;
+        error_log /var/vcap/sys/log/nginx/error.log   info;
+        events {
+          worker_connections  1024;
+        }
+        http {
+          server_tokens off;
+          server {
+            listen 80;
+            return 301 https://$host$request_uri;
+          }
+          server {
+            listen 443 default_server ssl;
+
+            ssl_certificate     /var/vcap/jobs/nginx/etc/ssl_chained.crt.pem;
+            ssl_certificate_key /var/vcap/jobs/nginx/etc/ssl.key.pem;
+            ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
+            ssl_ciphers         HIGH:!aNULL:!MD5;
+
+            set $upstream 10.244.0.34;
+
+            location / {
+              proxy_pass_request_headers on;
+              proxy_pass http://$upstream;
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header Host $host;
+              proxy_http_version 1.1;
+              proxy_set_header Connection "";
+              proxy_buffering off;
+              client_max_body_size 0;
+              proxy_read_timeout 36000s;
+              proxy_redirect off;
+            }
+
+            auth_basic           "Alto, santo y senha!";
+            auth_basic_user_file /var/vcap/jobs/nginx/etc/htpasswd.conf;
+          }
+        }
+update:
+  canaries: 1
+  max_in_flight: 1
+  serial: false
+  canary_watch_time: 1000-60000
+  update_watch_time: 1000-60000
+
+variables:
+- name: nginx_basic_auth_password
+  type: password
+
+- name: nginx_ca
+  type: certificate
+  options:
+    is_ca: true
+    common_name: routerCA
+
+- name: nginx
+  type: certificate
+  options:
+    ca: nginx_ca
+    common_name: routerSSL
+    alternative_names:
+    - "((system_domain))"
+    - "*.((system_domain))"
+

--- a/aws/manifests/nginx.yml
+++ b/aws/manifests/nginx.yml
@@ -62,16 +62,9 @@ instance_groups:
 
             set $upstream 10.244.0.34;
 
-            location /poor_mans_auth {
-              auth_basic           "Alto, santo y senha!";
-              auth_basic_user_file /var/vcap/jobs/nginx/etc/htpasswd.conf;
-              add_header Set-Cookie "POOR_MANS_AUTH=((nginx_basic_auth_password));Domain=.bosh-lite-1.sandbox.keytwine.com";
-              return 301 $arg_orig;
-            }
-
             location / {
-              if ($cookie_POOR_MANS_AUTH != "((nginx_basic_auth_password))") {
-                return 301 https://$host/poor_mans_auth?orig=$scheme://$host$uri;
+              if ($host !~ "^.*\.((public_system_domain))$") {
+                return 404;
               }
               proxy_pass_request_headers on;
               proxy_pass http://$upstream;

--- a/aws/manifests/nginx.yml
+++ b/aws/manifests/nginx.yml
@@ -62,7 +62,17 @@ instance_groups:
 
             set $upstream 10.244.0.34;
 
+            location /poor_mans_auth {
+              auth_basic           "Alto, santo y senha!";
+              auth_basic_user_file /var/vcap/jobs/nginx/etc/htpasswd.conf;
+              add_header Set-Cookie "POOR_MANS_AUTH=((nginx_basic_auth_password));Domain=.bosh-lite-1.sandbox.keytwine.com";
+              return 301 $arg_orig;
+            }
+
             location / {
+              if ($cookie_POOR_MANS_AUTH != "((nginx_basic_auth_password))") {
+                return 301 https://$host/poor_mans_auth?orig=$scheme://$host$uri;
+              }
               proxy_pass_request_headers on;
               proxy_pass http://$upstream;
               proxy_set_header X-Real-IP $remote_addr;
@@ -77,8 +87,6 @@ instance_groups:
               proxy_redirect off;
             }
 
-            auth_basic           "Alto, santo y senha!";
-            auth_basic_user_file /var/vcap/jobs/nginx/etc/htpasswd.conf;
           }
         }
 update:

--- a/aws/manifests/nginx.yml
+++ b/aws/manifests/nginx.yml
@@ -68,6 +68,7 @@ instance_groups:
               proxy_set_header X-Real-IP $remote_addr;
               proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
               proxy_set_header Host $host;
+              proxy_set_header Authorization "";
 
               proxy_http_version 1.1;
               proxy_set_header Connection "";

--- a/aws/manifests/nginx.yml
+++ b/aws/manifests/nginx.yml
@@ -3,12 +3,9 @@ name: nginx
 
 releases:
 - name: nginx
-  #version: "1.12.2"
-  #url: https://github.com/cloudfoundry-community/nginx-release/releases/download/v1.12.2/nginx-1.12.2.tgz
-  #sha1: e5e5f54d46e2a70fac85ba16e96ccb7e4148bdfa
-  version: "1.12.2+dev.9"
-  url: https://github.com/keymon/nginx-release/releases/download/1.12.2%2Bdev.9/nginx-release-1.12.2.dev.9.tar.gz
-  sha1: a3e6b1f4d327c8269d5108751da0b4e4a2733714
+  version: "1.12.2"
+  url: https://github.com/cloudfoundry-community/nginx-release/releases/download/v1.12.2/nginx-1.12.2.tgz
+  sha1: e5e5f54d46e2a70fac85ba16e96ccb7e4148bdfa
 
 stemcells:
 - alias: ubuntu
@@ -30,9 +27,17 @@ instance_groups:
   - name: nginx
     release: nginx
     properties:
-      htpasswd_users:
-      - name: bosh-lite
-        password: ((nginx_basic_auth_password))
+      pre_start: |
+        #!/bin/bash
+        JOB_NAME=nginx
+        BASE_DIR=/var/vcap
+        JOB_DIR=$BASE_DIR/jobs/$JOB_NAME
+        CONFIG_DIR=$JOB_DIR/etc
+
+        USER=admin
+        PASS="((nginx_basic_auth_password))"
+        echo "${USER}:$(echo "${PASS}" | openssl passwd -apr1 -stdin)" > ${CONFIG_DIR}/htpasswd.conf
+
       ssl_key: ((nginx.private_key))
       ssl_chained_cert: ((nginx.certificate))
       nginx_conf: |
@@ -63,6 +68,7 @@ instance_groups:
               proxy_set_header X-Real-IP $remote_addr;
               proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
               proxy_set_header Host $host;
+
               proxy_http_version 1.1;
               proxy_set_header Connection "";
               proxy_buffering off;

--- a/aws/manifests/nginx.yml
+++ b/aws/manifests/nginx.yml
@@ -68,7 +68,6 @@ instance_groups:
               proxy_set_header X-Real-IP $remote_addr;
               proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
               proxy_set_header Host $host;
-              proxy_set_header Authorization "";
 
               proxy_http_version 1.1;
               proxy_set_header Connection "";

--- a/aws/manifests/nginx.yml
+++ b/aws/manifests/nginx.yml
@@ -24,6 +24,8 @@ instance_groups:
   stemcell: ubuntu
   networks:
   - name: default
+    static_ips:
+    - 10.244.3.34
   jobs:
   - name: nginx
     release: nginx

--- a/aws/ops-files/bosh/forward-port-nginx.yml
+++ b/aws/ops-files/bosh/forward-port-nginx.yml
@@ -1,0 +1,26 @@
+---
+# Use the networking release to forward the ports to nginx
+- type: replace
+  path: /releases/name=networking?
+  value:
+    name: networking
+    version: 9
+    url: https://bosh.io/d/github.com/cloudfoundry/networking-release?v=9
+    sha1: 9b5f9d27917c3754e492470ac6c9af80d62963db
+
+# Add the job that redirects the ports
+- type: replace
+  path: /instance_groups/name=bosh/jobs/name=port_forwarding?
+  value:
+    name: port_forwarding
+    release: networking
+    properties:
+      networking:
+        port_forwarding:
+        - external_port: 80
+          internal_ip: 10.244.3.34
+          internal_port: 80
+        - external_port: 443
+          internal_ip: 10.244.3.34
+          internal_port: 443
+

--- a/aws/ops-files/prometheus/register_public_domains.yml
+++ b/aws/ops-files/prometheus/register_public_domains.yml
@@ -1,0 +1,11 @@
+---
+# Route Registrar
+- type: replace
+  path: /instance_groups/name=nginx/jobs/name=route_registrar/properties/route_registrar/routes/name=alertmanager?/uris/-
+  value: alertmanager.((public_system_domain))
+- type: replace
+  path: /instance_groups/name=nginx/jobs/name=route_registrar/properties/route_registrar/routes/name=prometheus?/uris/-
+  value: prometheus.((public_system_domain))
+- type: replace
+  path: /instance_groups/name=nginx/jobs/name=route_registrar/properties/route_registrar/routes/name=grafana?/uris/-
+  value: grafana.((public_system_domain))

--- a/aws/terraform/dns.tf
+++ b/aws/terraform/dns.tf
@@ -1,0 +1,11 @@
+data "aws_route53_zone" "dns_zone" {
+  name         = "${var.dns_zone_name}."
+}
+
+resource "aws_route53_record" "wildcard_public_record" {
+  zone_id = "${data.aws_route53_zone.dns_zone.zone_id}"
+  name    = "*.${var.public_system_domain}"
+  type    = "A"
+  ttl     = "60"
+  records = ["${aws_eip.bosh_lite.public_ip}"]
+}

--- a/aws/terraform/outputs.tf
+++ b/aws/terraform/outputs.tf
@@ -42,6 +42,7 @@ output "bosh_security_groups" {
   value = [
     "${aws_security_group.admin-access-ssh.name}",
     "${aws_security_group.admin-access-bosh.name}",
+    "${aws_security_group.allow-web-access.name}",
   ]
 }
 

--- a/aws/terraform/outputs.tf
+++ b/aws/terraform/outputs.tf
@@ -57,3 +57,7 @@ output "bosh_lite_instance_profile" {
 output "bosh_lite_external_ip" {
   value = "${aws_eip.bosh_lite.public_ip}"
 }
+
+output "public_system_domain" {
+  value = "${var.public_system_domain}"
+}

--- a/aws/terraform/security-groups.tf
+++ b/aws/terraform/security-groups.tf
@@ -46,4 +46,27 @@ resource "aws_security_group" "admin-access-bosh" {
   }
 }
 
+resource "aws_security_group" "allow-web-access" {
+  vpc_id      = "${aws_vpc.bosh-lite.id}"
+  name        = "${var.env}-allow-web-access"
+  description = "Allow access from allowed admin IPs to web ports: 80 and 443"
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["${formatlist("%s/32", concat(var.admin_cidrs, list(aws_eip.bosh_lite.public_ip)))}"]
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["${formatlist("%s/32", concat(var.admin_cidrs, list(aws_eip.bosh_lite.public_ip)))}"]
+  }
+
+  tags {
+    Name = "${var.env}-allow-web-access"
+  }
+}
 

--- a/aws/terraform/terraform-vars.sh
+++ b/aws/terraform/terraform-vars.sh
@@ -1,5 +1,9 @@
 export TF_VAR_env="${DEPLOY_ENV}"
 
+export TF_VAR_dns_zone_name="${DNS_ZONE_NAME}"
+
+export TF_VAR_public_system_domain="${PUBLIC_SYSTEM_DOMAIN}"
+
 export TF_VAR_aws_account_id="$(pass keytwine/aws/sandbox/account_id)"
 
 current_ip="$(cat ../generated/current_ip.txt)"

--- a/aws/terraform/variables.tf
+++ b/aws/terraform/variables.tf
@@ -3,12 +3,20 @@ variable "env" {
   default = "bosh-lite-1"
 }
 
-variable "region" {
-  default = "eu-west-1"
+variable "dns_zone_name" {
+  description = "DNS zone name where register domains"
+}
+
+variable "public_system_domain" {
+  description = "Public system domain for this deployment"
 }
 
 variable "aws_account_id" {
-    description = "Root account id"
+  description = "Root account id"
+}
+
+variable "region" {
+  default = "eu-west-1"
 }
 
 variable "vpc_cidr" {


### PR DESCRIPTION
We want to demo some stuff from cloudfoundry (e.g. prometheus+CF) but we do not really know the public IPs of the clients.

We setup a public DNS name to point to the services. Self signed certs are OK for the time being.

We do not want to publish all the go-reouter from bosh-lite to the internet, so we would expose the gorouter via a nginx reverse proxy which would check that the Host header is one of the published ones. Then we expose the nginx server using the port_forwarding job form the networking release in the bosh-lite VM.

We would open the IPs in the security group only the days of the demo.